### PR TITLE
tokens: Implement validity check, define token lifetimes as DateTime<Utc> (instead of string)

### DIFF
--- a/examples/src/bin/auth_minecraft.rs
+++ b/examples/src/bin/auth_minecraft.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<(), Error> {
         )
         .await?;
 
+    xsts_mc_services.check_validity()?;
     let identity_token = xsts_mc_services.authorization_header_value();
     println!("identityToken: {identity_token}");
 

--- a/examples/src/bin/xbl_signed_request.rs
+++ b/examples/src/bin/xbl_signed_request.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let xsts_token = token_store
         .authorization_token
         .ok_or(Error::GeneralError("No XSTS token was acquired".into()))?;
+    xsts_token.check_validity()?;
 
     // Send a http request
     // Request will get signed and MS-CV header populated

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Definition of custom error type.
 //!
 
+use chrono::{DateTime, Utc};
 use oauth2::{
     basic::BasicErrorResponse, reqwest::AsyncHttpClientError, DeviceCodeErrorResponse,
     RequestTokenError,
@@ -65,6 +66,9 @@ pub enum Error {
     /// Failed processing HTTP request
     #[error("Failed processing HTTP request")]
     InvalidRequest(String),
+    /// Token expired
+    #[error("Token expired")]
+    TokenExpired(DateTime<Utc>),
     /// Unknown error
     #[error("unknown xal error")]
     Unknown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!         &mut authenticator,
 //!         CliCallbackHandler
 //!     ).await?;
-//! 
+//!
 //!     // User will be prompted on commandline to proceed with authentication
 //!
 //!     token_store.update_timestamp();


### PR DESCRIPTION
^